### PR TITLE
Bind Alternate for ESC in .vimrc

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -11,3 +11,5 @@ autocmd BufRead,BufNewFile *.py2 set filetype=python
 autocmd BufRead,BufNewFile *.py3 set filetype=python
 
 hi Comment ctermfg=LightBlue
+
+inoremap jj <esc>


### PR DESCRIPTION
Bind `jj` to ESC.